### PR TITLE
Slurm API

### DIFF
--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -209,7 +209,7 @@ def download(client, remote_path, local_path, recursive=False):
     scp.close()
 
 
-def execute_command(client, cmd):
+def execute_command(client, cmd, exit_status=True):
     """Executes a given shell command.
 
     Executes a given shell command using the SSH connection provided by client object
@@ -226,4 +226,11 @@ def execute_command(client, cmd):
     stdin, stdout, stderr = client.exec_command(cmd)
     out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
-    print(err) if err else print(out)
+    
+    if exit_status:
+        if err:
+            print(err, '\nExit code for ' + "\"" + cmd + "\"" + ' command in execute_command:', str(stderr.channel.recv_exit_status()))
+        else:
+            print(out, '\nExit code for ' + "\"" + cmd + "\"" + ' command in execute_command:', str(stdout.channel.recv_exit_status()))
+    else:
+        print(err) if err else print(out)

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -55,7 +55,7 @@ def list_data_provider(client, path):
     stderr is printed and None is returned.
 
     Args:
-        client: A paramiko.client.SSHClient object with SSH connection to execute shell command.
+        client: A paramiko.client.SSHClient object with SSH connection to execute the shell command.
         path: A string representing the path of the designated location.
 
     Returns:
@@ -100,6 +100,39 @@ def post_task(client, path):
 
 
 def get_all_tasks(client):
+    """Gets all tasks in queue.
+
+    Retrieves all tasks by executing a 'squeue' command using the SSH connection
+    provided by client object. If the command executes with no error it parses
+    the stdout, structures it into a dictionary and returns it otherwise, it prints
+    the stderr.
+
+    Args:
+        client: A paramiko.client.SSHClient object with SSH connection to execute the shell command.
+
+    Returns:
+        A dict mapping each job_id to a dictionary that maps task information headers to their
+        respective values if the command executes with no error otherwise None. Example of 
+        returned dictionary:
+
+        {'40749727': 
+                    {
+                        'USER': 'johndoe',
+                        'ACCOUNT': 'def-joh_C',
+                        'NAME': '4carm0.1.24',
+                        'ST': 'R',
+                        'TIME_LEFT': '1:26',
+                        'NODES': '3',
+                        'CPUS': '4',
+                        'TRES_PER_N': 'N/A',
+                        'MIN_MEM': '16',
+                        'NODELIST (REASON)': 'cdr[1705-1706,1712] (None)'
+                    }
+
+        }
+
+        Returned keys and values are all strings.
+    """
 
     stdin, stdout, stderr = client.exec_command('squeue')
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -41,7 +41,7 @@ def list_data_provider(client, path):
     return out.split('\n')
 
 def post_task(client, remote_path):
-    
+
     cd_path = '/'.join(remote_path.split('/')[:-1])
     shell_name = remote_path.split('/')[-1]
     stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + shell_name)
@@ -52,8 +52,17 @@ def post_task(client, remote_path):
     else:
         print(out)
 
-def get_all_tasks():
-    pass
+def get_all_tasks(client):
+
+    stdin, stdout, stderr = client.exec_command('squeue')
+    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+
+    if err:
+        print(err)
+        return None
+    else:
+        out = [i.split()[:10] + [' '.join(i.split()[10:])] for i in out.split('\n')]
+        return dict(zip([i[0] for i in out[1:-1]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:-1]))))
 
 def upload():
     pass

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -70,8 +70,7 @@ def list_data_provider(client, path):
         print(err)
     else:
         print(out)
-    
-    return out.split('\n')
+        return out.split('\n')
 
 
 def post_task(client, path):

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -78,8 +78,10 @@ def post_task(client, path):
 
     Submits a task located in the input path to Slurm using the SSH connection 
     provided by client object to execute 'cd' command to first change the 
-    current working directory to where the task file is located (cd path) 
-    and then submit the task (task_file) by executing 'sbatch' command.  
+    current working directory to where the task file is located (cd path),
+    then submit the task (task_file) by executing 'sbatch' command, and 
+    prints the stdout if the command executes with no error otherwise
+    prints the error.
 
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute shell commands.

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -23,7 +23,7 @@ def login(hostname, username, password, port=22):
     host = hostname
     client = paramiko.SSHClient()
     client.load_system_host_keys()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())    # Vulnerability to possible MITM attack
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     client.connect(hostname, port, username, password)
     print('Connection to', host, 'established.')
 
@@ -64,12 +64,11 @@ def list_data_provider(client, path):
     """
 
     stdin, stdout, stderr = client.exec_command('ls -r ' + path)
-    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+    out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
     if err:
-        print(err[:-1])
+        print(err)
     else:
-        print(out[:-1])
         return out.split('\n')
 
 
@@ -94,9 +93,9 @@ def post_task(client, path):
     cd_path = '/'.join(path.split('/')[:-1])
     task_file = path.split('/')[-1]
     stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + task_file)
-    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+    out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
-    print(err[:-1]) if err else print(out[:-1])
+    print(err) if err else print(out)
 
 
 def get_all_tasks(client):
@@ -135,13 +134,13 @@ def get_all_tasks(client):
     """
 
     stdin, stdout, stderr = client.exec_command('squeue')
-    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+    out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
     if err:
-        print(err[:-1])
+        print(err)
     else:
         out = [i.split()[:10] + [' '.join(i.split()[10:])] for i in out.split('\n')]
-        return dict(zip([i[0] for i in out[1:-1]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:-1]))))
+        return dict(zip([i[0] for i in out[1:]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:]))))
 
 
 def upload(client, local_path, remote_path, recursive=False):
@@ -201,8 +200,8 @@ def execute_command(client, cmd):
     """
 
     stdin, stdout, stderr = client.exec_command(cmd)
-    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+    out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
-    print(err[:-1]) if err else print(out[:-1])
+    print(err) if err else print(out)
         
 

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -1,8 +1,26 @@
+import paramiko
 
 ##################################################################################
 
-def login():
-    pass
+def login(hostname, username, password, port=22):
+    global host
+    host = hostname
+    client = paramiko.SSHClient()
+    client.load_system_host_keys()
+    # Vulnerability to possible MITM attack
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(hostname, port, username, password)
+    except paramiko.BadHostKeyException:
+        print('Server’s host key could not be verified.')
+    except paramiko.AuthenticationException:
+        print('Authentication failed.')
+    except paramiko.SSHException:
+        print('An error occured while connecting\n An SSH session could not be established.')
+    else:
+        print('Connection to', host, 'established.')
+
+        return client
 
 def logout():
     pass

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -1,0 +1,23 @@
+
+##################################################################################
+
+def login():
+    pass
+
+def logout():
+    pass
+
+def list_data_provider():
+    pass
+
+def upload():
+    pass
+
+def post_task():
+    pass
+
+def get_all_tasks():
+    pass
+
+def download():
+    pass

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -26,8 +26,17 @@ def logout(client):
     client.close()
     print('Connection to', host, 'was closed.')
 
-def list_data_provider():
-    pass
+def list_data_provider(client, path):
+
+    stdin, stdout, stderr = client.exec_command('ls -r ' + path)
+    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+
+    if err:
+        print(err)
+    else:
+        print(out)
+    
+    return out.split('\n')
 
 def upload():
     pass

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -114,15 +114,16 @@ def post_task(client, path, exit_status=True):
 
 
 def get_all_tasks(client, exit_status=True):
-    """Gets all tasks in queue.
+    """Retrieves all tasks in queue.
 
-    Retrieves all tasks by executing a 'squeue' command using the SSH connection
-    provided by client object. If the command executes with no error it parses
-    the stdout, structures it into a dictionary and returns it otherwise, it prints
-    the stderr.
+    Gets all tasks by executing an 'squeue' command using the SSH connection
+    provided by client object. If the command executes with no error (prints the exit status and)
+    it parses the stdout, structures it into a dictionary and returns it otherwise, it prints
+    the stderr (and the exit status).
 
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute the shell command.
+        exit_status: A boolean representing a flag when true the function prints the exit status of the executed shell command (default True).
 
     Returns:
         A dictionary mapping each job_id to a dictionary that maps task information headers to their

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -24,7 +24,7 @@ def login(hostname, username, password, port=22):
     client.load_system_host_keys()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     client.connect(hostname, port, username, password)
-    print('Connection to', host, 'established.')
+    print('Connection to', hostname, 'established.')
 
     return client
 

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -80,10 +80,7 @@ def post_task(client, path):
     stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + shell_file)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
 
-    if err:
-        print(err)
-    else:
-        print(out)
+    print(err[:-1]) if err else print(out[:-1])
 
 
 def get_all_tasks(client):

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -56,7 +56,7 @@ def list_data_provider(client, path, exit_status=True):
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute the shell command.
         path: A string representing the path of the designated location.
-        exit_status: boolean representing a flag when true the function prints the exit status of the executed shell command (default True).
+        exit_status: A boolean allows the exit status of the executed shell command to be printed (default True).
 
     Returns:
         A list of strings where each string represents the available files in the given path
@@ -92,7 +92,7 @@ def post_task(client, path, exit_status=True):
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute shell commands.
         path: A string representing the path to the task file's location.
-        exit_status: boolean representing a flag when true the function prints the exit status of the executed shell command (default True).
+        exit_status: A boolean allows the exit status of the executed shell command to be printed (default True).
     
     Returns:
         None.
@@ -122,7 +122,7 @@ def get_all_tasks(client, exit_status=True):
 
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute the shell command.
-        exit_status: A boolean representing a flag when true the function prints the exit status of the executed shell command (default True).
+        exit_status: A boolean allows the exit status of the executed shell command to be printed (default True).
 
     Returns:
         A dictionary mapping each job_id to a dictionary that maps task information headers to their
@@ -217,7 +217,7 @@ def execute_command(client, cmd, exit_status=True):
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute the given shell command.
         cmd: A string representing the shell command to be executed.
-        exit_status: A boolean allows the function to print the exit status of the executed shell command (default True).
+        exit_status: A boolean allows the exit status of the executed shell command to be printed (default True).
 
     Returns:
         None.

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -80,7 +80,7 @@ def list_data_provider(client, path, exit_status=True):
             return out.split('\n')
 
 
-def post_task(client, path):
+def post_task(client, path, exit_status=True):
     """Posts a task located in the given path to Slurm.
 
     Submits a task located in the input path to Slurm using the SSH connection 
@@ -102,8 +102,14 @@ def post_task(client, path):
     task_file = path.split('/')[-1]
     stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + task_file)
     out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
-
-    print(err) if err else print(out)
+    
+    if exit_status:
+        if err:
+            print(err, '\nExit code for \"sbatch\" command in post_task:', str(stderr.channel.recv_exit_status()))
+        else:
+            print(out, '\nExit code for \"sbatch\" command in post_task:', str(stdout.channel.recv_exit_status()))
+    else:
+        print(err) if err else print(out)
 
 
 def get_all_tasks(client):
@@ -211,5 +217,3 @@ def execute_command(client, cmd):
     out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
     print(err) if err else print(out)
-        
-

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -19,8 +19,7 @@ def login(hostname, username, password, port=22):
     Returns:
         A paramiko.client.SSHClient object representing the client object with SSH connection.
     """
-    global host
-    host = hostname
+
     client = paramiko.SSHClient()
     client.load_system_host_keys()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -43,7 +42,7 @@ def logout(client):
     """
 
     client.close()
-    print('Connection to', host, 'was closed.')
+    print('Connection was closed.')
 
 
 def list_data_provider(client, path, exit_status=True):

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -218,6 +218,7 @@ def execute_command(client, cmd, exit_status=True):
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute the given shell command.
         cmd: A string representing the shell command to be executed.
+        exit_status: A boolean allows the function to print the exit status of the executed shell command (default True).
 
     Returns:
         None.

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -108,8 +108,13 @@ def post_task(client, path, exit_status=True):
             print(err, '\nExit code for \"sbatch\" command in post_task:', str(stderr.channel.recv_exit_status()))
         else:
             print(out, '\nExit code for \"sbatch\" command in post_task:', str(stdout.channel.recv_exit_status()))
+            return out.split()[-1]
     else:
-        print(err) if err else print(out)
+        if err:
+            print(err)  
+        else:
+            print(out)
+            return out.split()[-1]
 
 
 def get_all_tasks(client, exit_status=True):

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -55,7 +55,7 @@ def list_data_provider(client, path):
     stderr is printed and None is returned.
 
     Args:
-        client: A paramiko.client.SSHClient object with SSH connection to execute command.
+        client: A paramiko.client.SSHClient object with SSH connection to execute shell command.
         path: A string representing the path of the designated location.
 
     Returns:
@@ -74,10 +74,24 @@ def list_data_provider(client, path):
 
 
 def post_task(client, path):
+    """Posts a task located in the given path to Slurm.
+
+    Submits a task located in the input path to Slurm using the SSH connection 
+    provided by client object to execute 'cd' command to first change the 
+    current working directory to where the task file is located (cd path) 
+    and then submit the task (task_file) by executing 'sbatch' command.  
+
+    Args:
+        client: A paramiko.client.SSHClient object with SSH connection to execute shell commands.
+        path: A string representing the path to the task file's location.
+    
+    Returns:
+        None.
+    """
 
     cd_path = '/'.join(remote_path.split('/')[:-1])
-    shell_file = remote_path.split('/')[-1]
-    stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + shell_file)
+    task_file = remote_path.split('/')[-1]
+    stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + task_file)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
 
     print(err[:-1]) if err else print(out[:-1])

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -154,7 +154,7 @@ def upload(client, local_path, remote_path, recursive=False):
         local_path: A string representing a single path, or a list of strings representing paths on local machine to be transferred.
                     recursive must be True to transfer directories.
         remote_path: A string representing the path on the remote machine where the files will be transferred to.
-        recursive: A boolean to allow the transfer of files and directories recursively.
+        recursive: A boolean to allow the transfer of files and directories recursively (default False).
     
     Returns:
         None.
@@ -175,7 +175,7 @@ def download(client, remote_path, local_path, recursive=False):
         remote_path: A string representing a single path on remote machine to be transferred.
                      recursive must be True to transfer directories.
         local_path: A string representing the path on the local machine where the files will be transferred to.
-        recursive: A boolean to allow the transfer of files and directories recursively.
+        recursive: A boolean to allow the transfer of files and directories recursively (default False).
 
     Returns:
         None.

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -150,8 +150,6 @@ def get_all_tasks(client, exit_status=True):
                     }
 
         }
-
-        Returned keys and values are all strings.
     """
 
     stdin, stdout, stderr = client.exec_command('squeue')

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -147,11 +147,11 @@ def get_all_tasks(client):
 def upload(client, local_path, remote_path, recursive=False):
     """Transfers files and directoreis from local machine to remote machine.
 
-    Uploads files and directories using scp module and client object with SSH connection.
+    Uploads files and directories using scp module and client object.
 
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to get the transport from and initialize the SCPClient object.
-        local_path: A string representing a single path, or a list of strings representing paths to be transferred.
+        local_path: A string representing a single path, or a list of strings representing paths on local machine to be transferred.
                     recursive must be True to transfer directories.
         remote_path: A string representing the path on the remote machine where the files will be transferred to.
         recursive: A boolean to allow the transfer of files and directories recursively.
@@ -166,6 +166,20 @@ def upload(client, local_path, remote_path, recursive=False):
 
 
 def download(client, remote_path, local_path, recursive=False):
+    """Transfers files and directories from remote machine to local machine.
+
+    Downloads files and directories using scp module and client object.
+
+    Args:
+        client: A paramiko.client.SSHClient object with SSH connection to get the transport from and initialize the SCPClient object.
+        remote_path: A string representing a single path on remote machine to be transferred.
+                     recursive must be True to transfer directories.
+        local_path: A string representing the path on the local machine where the files will be transferred to.
+        recursive: A boolean to allow the transfer of files and directories recursively.
+
+    Returns:
+        None.
+    """
 
     scp = SCPClient(client.get_transport())
     scp.get(remote_path, local_path, recursive)

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -67,9 +67,9 @@ def list_data_provider(client, path):
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
 
     if err:
-        print(err)
+        print(err[:-1])
     else:
-        print(out)
+        print(out[:-1])
         return out.split('\n')
 
 
@@ -105,7 +105,7 @@ def get_all_tasks(client):
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
 
     if err:
-        print(err)
+        print(err[:-1])
     else:
         out = [i.split()[:10] + [' '.join(i.split()[10:])] for i in out.split('\n')]
         return dict(zip([i[0] for i in out[1:-1]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:-1]))))

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -1,4 +1,5 @@
 import paramiko
+from shlex import quote
 from scp import SCPClient
 
 ##################################################################################
@@ -63,7 +64,7 @@ def list_data_provider(client, path, exit_status=True):
         if the command executes with no error otherwise None.
     """
 
-    stdin, stdout, stderr = client.exec_command('ls -r ' + path)
+    stdin, stdout, stderr = client.exec_command('ls -r ' + quote(path))
     out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
     if exit_status:
@@ -99,6 +100,7 @@ def post_task(client, path, exit_status=True):
         A string representing the job id of the posted task if the command executes with no error otherwise None.
     """
 
+    path = quote(path)
     cd_path = '/'.join(path.split('/')[:-1])
     task_file = path.split('/')[-1]
     stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + task_file)

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -4,7 +4,21 @@ from scp import SCPClient
 ##################################################################################
 
 def login(hostname, username, password, port=22):
+    """Establishes SSH connection.
     
+    Connects to an SSH server and authenticates to it. The server's host key is 
+    checked against The loaded system host (load_system_host_keys()). If the server's
+    hostname is not found, It is automatically added (set_missing_host_key_policy()).
+
+    Args:
+        hostname: A string representing the server to connect to
+        username: A string representing the username to authenticate as
+        password: A string password to authenticate 
+        port: An integer representing the server port to connect to (default 22)
+
+    Returns:
+        A paramiko.client.SSHClient object representing the client object with SSH connection
+    """
     global host
     host = hostname
     client = paramiko.SSHClient()

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -130,8 +130,6 @@ def execute_command(client, cmd):
     stdin, stdout, stderr = client.exec_command(cmd)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
 
-    if err:
-        print(err)
-    else:
-        print(out)
+    print(err[:-1]) if err else print(out[:-1])
+        
 

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -1,4 +1,5 @@
 import paramiko
+from scp import SCPClient
 
 ##################################################################################
 
@@ -64,8 +65,11 @@ def get_all_tasks(client):
         out = [i.split()[:10] + [' '.join(i.split()[10:])] for i in out.split('\n')]
         return dict(zip([i[0] for i in out[1:-1]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:-1]))))
 
-def upload():
-    pass
+def upload(client, local_path, remote_path, recursive=False):
+    
+    scp = SCPClient(client.get_transport())
+    scp.put(local_path, remote_path, recursive)
+    scp.close()
 
 def download():
     pass

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -47,6 +47,21 @@ def logout(client):
 
 
 def list_data_provider(client, path):
+    """Lists existing files in the given path.
+
+    Generates a list of the available files in the input path using SSH connection
+    provided by client object to execute 'ls -r' command. If the command executes
+    with no error, the stdout is printed and the list is returned otherwise the 
+    stderr is printed and None is returned.
+
+    Args:
+        client: A paramiko.client.SSHClient object with SSH connection to execute command.
+        path: A string representing the path of the designated location.
+
+    Returns:
+        A list of strings where each string represents the available files in the given path
+        if the command executes with no error otherwise None.
+    """
 
     stdin, stdout, stderr = client.exec_command('ls -r ' + path)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -24,10 +24,12 @@ def login(hostname, username, password, port=22):
 
         return client
 
+
 def logout(client):
 
     client.close()
     print('Connection to', host, 'was closed.')
+
 
 def list_data_provider(client, path):
 
@@ -41,6 +43,7 @@ def list_data_provider(client, path):
     
     return out.split('\n')
 
+
 def post_task(client, remote_path):
 
     cd_path = '/'.join(remote_path.split('/')[:-1])
@@ -52,6 +55,7 @@ def post_task(client, remote_path):
         print(err)
     else:
         print(out)
+
 
 def get_all_tasks(client):
 
@@ -65,12 +69,16 @@ def get_all_tasks(client):
         out = [i.split()[:10] + [' '.join(i.split()[10:])] for i in out.split('\n')]
         return dict(zip([i[0] for i in out[1:-1]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:-1]))))
 
+
 def upload(client, local_path, remote_path, recursive=False):
+
     scp = SCPClient(client.get_transport())
     scp.put(local_path, remote_path, recursive)
     scp.close()
 
+
 def download(client, remote_path, local_path, recursive=False):
+
     scp = SCPClient(client.get_transport())
     scp.get(remote_path, local_path, recursive)
     scp.close()

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -40,8 +40,17 @@ def list_data_provider(client, path):
     
     return out.split('\n')
 
-def post_task():
-    pass
+def post_task(client, remote_path):
+    
+    cd_path = '/'.join(remote_path.split('/')[:-1])
+    shell_name = remote_path.split('/')[-1]
+    stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + shell_name)
+    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+
+    if err:
+        print(err)
+    else:
+        print(out)
 
 def get_all_tasks():
     pass

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -66,10 +66,11 @@ def get_all_tasks(client):
         return dict(zip([i[0] for i in out[1:-1]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:-1]))))
 
 def upload(client, local_path, remote_path, recursive=False):
-    
     scp = SCPClient(client.get_transport())
     scp.put(local_path, remote_path, recursive)
     scp.close()
 
-def download():
-    pass
+def download(client, remote_path, local_path, recursive=False):
+    scp = SCPClient(client.get_transport())
+    scp.get(remote_path, local_path, recursive)
+    scp.close()

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -4,25 +4,16 @@ from scp import SCPClient
 ##################################################################################
 
 def login(hostname, username, password, port=22):
-
+    
     global host
     host = hostname
     client = paramiko.SSHClient()
     client.load_system_host_keys()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())    # Vulnerability to possible MITM attack
+    client.connect(hostname, port, username, password)
+    print('Connection to', host, 'established.')
 
-    try:
-        client.connect(hostname, port, username, password)
-    except paramiko.BadHostKeyException:
-        print('Server’s host key could not be verified.')
-    except paramiko.AuthenticationException:
-        print('Authentication failed.')
-    except paramiko.SSHException:
-        print('An error occured while connecting\n An SSH session could not be established.')
-    else:
-        print('Connection to', host, 'established.')
-
-        return client
+    return client
 
 
 def logout(client):

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -11,13 +11,13 @@ def login(hostname, username, password, port=22):
     hostname is not found, It is automatically added (set_missing_host_key_policy()).
 
     Args:
-        hostname: A string representing the server to connect to
-        username: A string representing the username to authenticate as
-        password: A string password to authenticate 
-        port: An integer representing the server port to connect to (default 22)
+        hostname: A string representing the server to connect to.
+        username: A string representing the username to authenticate as.
+        password: A string representing password to authenticate.
+        port: An integer representing the server port to connect to (default 22).
 
     Returns:
-        A paramiko.client.SSHClient object representing the client object with SSH connection
+        A paramiko.client.SSHClient object representing the client object with SSH connection.
     """
     global host
     host = hostname

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -44,11 +44,11 @@ def list_data_provider(client, path):
     return out.split('\n')
 
 
-def post_task(client, remote_path):
+def post_task(client, path):
 
     cd_path = '/'.join(remote_path.split('/')[:-1])
-    shell_name = remote_path.split('/')[-1]
-    stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + shell_name)
+    shell_file = remote_path.split('/')[-1]
+    stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + shell_file)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
 
     if err:
@@ -88,7 +88,7 @@ def execute_command(client, cmd):
 
     stdin, stdout, stderr = client.exec_command(cmd)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
-    
+
     if err:
         print(err)
     else:

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -31,6 +31,16 @@ def login(hostname, username, password, port=22):
 
 
 def logout(client):
+    """Tears down the SSH connection.
+
+    Closes the paramiko.client.SSHClient object and it's underlying '.Transport'.
+
+    Args:
+        client: A paramiko.client.SSHClient object with SSH connection to be closed.
+
+    Returns:
+        None.
+    """
 
     client.close()
     print('Connection to', host, 'was closed.')

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -82,3 +82,15 @@ def download(client, remote_path, local_path, recursive=False):
     scp = SCPClient(client.get_transport())
     scp.get(remote_path, local_path, recursive)
     scp.close()
+
+
+def execute_command(client, cmd):
+
+    stdin, stdout, stderr = client.exec_command(cmd)
+    out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
+    
+    if err:
+        print(err)
+    else:
+        print(out)
+

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -104,7 +104,6 @@ def get_all_tasks(client):
 
     if err:
         print(err)
-        return None
     else:
         out = [i.split()[:10] + [' '.join(i.split()[10:])] for i in out.split('\n')]
         return dict(zip([i[0] for i in out[1:-1]], (map(lambda x: dict(zip(out[0][1:], x[1:])), out[1:-1]))))

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -3,12 +3,13 @@ import paramiko
 ##################################################################################
 
 def login(hostname, username, password, port=22):
+
     global host
     host = hostname
     client = paramiko.SSHClient()
     client.load_system_host_keys()
-    # Vulnerability to possible MITM attack
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())    # Vulnerability to possible MITM attack
+
     try:
         client.connect(hostname, port, username, password)
     except paramiko.BadHostKeyException:
@@ -23,6 +24,7 @@ def login(hostname, username, password, port=22):
         return client
 
 def logout(client):
+
     client.close()
     print('Connection to', host, 'was closed.')
 
@@ -38,13 +40,13 @@ def list_data_provider(client, path):
     
     return out.split('\n')
 
-def upload():
-    pass
-
 def post_task():
     pass
 
 def get_all_tasks():
+    pass
+
+def upload():
     pass
 
 def download():

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -85,9 +85,10 @@ def post_task(client, path, exit_status=True):
     Submits a task located in the input path to Slurm using the SSH connection 
     provided by client object to execute 'cd' command to first change the 
     current working directory to where the task file is located (cd path),
-    then submit the task (task_file) by executing 'sbatch' command, and 
-    prints the stdout (and the exit status) if the command executes with 
-    no error otherwise prints the error (and the exit status).
+    then submit the task (task_file) by executing 'sbatch' command, 
+    prints the stdout (and the exit status), and returns the job id of
+    the posted task if the command executes with no error otherwise 
+    prints the error (and the exit status).
 
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute shell commands.
@@ -95,7 +96,7 @@ def post_task(client, path, exit_status=True):
         exit_status: A boolean allows the exit status of the executed shell command to be printed (default True).
     
     Returns:
-        None.
+        A string representing the job id of the posted task if the command executes with no error otherwise None.
     """
 
     cd_path = '/'.join(path.split('/')[:-1])

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -51,12 +51,13 @@ def list_data_provider(client, path, exit_status=True):
 
     Generates a list of the available files in the input path using SSH connection
     provided by client object to execute 'ls -r' command. If the command executes
-    with no error, the stdout is printed and the list is returned otherwise the 
-    stderr is printed and None is returned.
+    with no error,(exit status is printed and) the list is returned otherwise the 
+    stderr (and exit status) is printed and None is returned.
 
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute the shell command.
         path: A string representing the path of the designated location.
+        exit_status: boolean representing a flag when true the function prints the exit status of the executed shell command (default True).
 
     Returns:
         A list of strings where each string represents the available files in the given path

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -187,6 +187,18 @@ def download(client, remote_path, local_path, recursive=False):
 
 
 def execute_command(client, cmd):
+    """Executes a given shell command.
+
+    Executes a given shell command using the SSH connection provided by client object
+    and prints the stdout if the command executes with no error otherwise prints stderr.
+
+    Args:
+        client: A paramiko.client.SSHClient object with SSH connection to execute the given shell command.
+        cmd: A string representing the shell command to be executed.
+
+    Returns:
+        None.
+    """
 
     stdin, stdout, stderr = client.exec_command(cmd)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -91,8 +91,8 @@ def post_task(client, path):
         None.
     """
 
-    cd_path = '/'.join(remote_path.split('/')[:-1])
-    task_file = remote_path.split('/')[-1]
+    cd_path = '/'.join(path.split('/')[:-1])
+    task_file = path.split('/')[-1]
     stdin, stdout, stderr = client.exec_command('cd ' + cd_path + ';sbatch ' + task_file)
     out, err = ''.join(stdout.readlines()), ''.join(stderr.readlines())
 

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -46,7 +46,7 @@ def logout(client):
     print('Connection to', host, 'was closed.')
 
 
-def list_data_provider(client, path):
+def list_data_provider(client, path, exit_status=True):
     """Lists existing files in the given path.
 
     Generates a list of the available files in the input path using SSH connection
@@ -66,10 +66,17 @@ def list_data_provider(client, path):
     stdin, stdout, stderr = client.exec_command('ls -r ' + path)
     out, err = ''.join(stdout.readlines())[:-1], ''.join(stderr.readlines())[:-1]
 
-    if err:
-        print(err)
+    if exit_status:
+        if err:
+            print(err, '\nExit code for \"ls -r\" command in list_data_provider:', str(stderr.channel.recv_exit_status()))
+        else:
+            print('Exit code for \"ls -r\" command in list_data_provider:', str(stdout.channel.recv_exit_status()))
+            return out.split('\n')
     else:
-        return out.split('\n')
+        if err:
+            print(err) 
+        else:
+            return out.split('\n')
 
 
 def post_task(client, path):

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -111,7 +111,7 @@ def get_all_tasks(client):
         client: A paramiko.client.SSHClient object with SSH connection to execute the shell command.
 
     Returns:
-        A dict mapping each job_id to a dictionary that maps task information headers to their
+        A dictionary mapping each job_id to a dictionary that maps task information headers to their
         respective values if the command executes with no error otherwise None. Example of 
         returned dictionary:
 
@@ -145,6 +145,20 @@ def get_all_tasks(client):
 
 
 def upload(client, local_path, remote_path, recursive=False):
+    """Transfers files and directoreis from local machine to remote machine.
+
+    Uploads files and directories using scp module and client object with SSH connection.
+
+    Args:
+        client: A paramiko.client.SSHClient object with SSH connection to get the transport from and initialize the SCPClient object.
+        local_path: A string representing a single path, or a list of strings representing paths to be transferred.
+                    recursive must be True to transfer directories.
+        remote_path: A string representing the path on the remote machine where the files will be transferred to.
+        recursive: A boolean to allow the transfer of files and directories recursively.
+    
+    Returns:
+        None.
+    """
 
     scp = SCPClient(client.get_transport())
     scp.put(local_path, remote_path, recursive)

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -22,8 +22,9 @@ def login(hostname, username, password, port=22):
 
         return client
 
-def logout():
-    pass
+def logout(client):
+    client.close()
+    print('Connection to', host, 'was closed.')
 
 def list_data_provider():
     pass

--- a/slurmAPI.py
+++ b/slurmAPI.py
@@ -87,12 +87,13 @@ def post_task(client, path, exit_status=True):
     provided by client object to execute 'cd' command to first change the 
     current working directory to where the task file is located (cd path),
     then submit the task (task_file) by executing 'sbatch' command, and 
-    prints the stdout if the command executes with no error otherwise
-    prints the error.
+    prints the stdout (and the exit status) if the command executes with 
+    no error otherwise prints the error (and the exit status).
 
     Args:
         client: A paramiko.client.SSHClient object with SSH connection to execute shell commands.
         path: A string representing the path to the task file's location.
+        exit_status: boolean representing a flag when true the function prints the exit status of the executed shell command (default True).
     
     Returns:
         None.


### PR DESCRIPTION
This PR includes the implementation of Slurm API.

Slurm API allows NeuroCI to accomplish a number of tasks on a remote server (running Slurm) in pure Python by utilizing SSH connection without the need to access the terminal. It is developed using Paramiko and python's scp library to replace the existing Cbrain API and to help generalize the NeuroCI framework.

List of Slurm API functions and their counterparts in Cbrain API:
- login &rarr; cbrain_login
- logout &rarr; cbrain_logout
- list_data_provider &rarr; cbrain_list_data_provider
- post_task &rarr; cbrain_post_task
- get_all_tasks &rarr; cbrain_get_all_tasks
- upload &rarr; N/A
- download &rarr; cbrain_download_file
- execute_command &rarr; N/A

All of the above functions have been locally tested with various simple use cases however, the API hasn't been tested with automated testing.